### PR TITLE
fix: handle rolldown stats output with getters

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -102,13 +102,7 @@ function cloneWithGettersUsingStructuredClone<T extends Record<any, any>>(obj: T
   const plainObject: any = {};
 
   for (const key of Reflect.ownKeys(obj)) {
-    const descriptor = Object.getOwnPropertyDescriptor(obj, key);
-
-    if (descriptor?.get) {
-      plainObject[key] = obj[key as keyof typeof obj];
-    } else {
-      plainObject[key] = obj[key as keyof typeof obj];
-    }
+    plainObject[key] = obj[key as keyof typeof obj];
   }
 
   // Use structuredClone to deeply clone the resulting plain object

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -45,7 +45,7 @@ export default function extractRollupStats(bundle: OutputBundle, options: StatsO
     }
 
     if (bundleEntryStats.type === "asset") {
-      let assetStats = structuredClone(bundleEntryStats) as AssetStats;
+      let assetStats = cloneWithGettersUsingStructuredClone(bundleEntryStats) as AssetStats;
 
       // Skip asset source if options source is false
       if (!source) {
@@ -58,7 +58,7 @@ export default function extractRollupStats(bundle: OutputBundle, options: StatsO
     }
 
     if (bundleEntryStats.type === "chunk") {
-      let chunkStats = structuredClone(bundleEntryStats) as ChunkStats;
+      let chunkStats = cloneWithGettersUsingStructuredClone(bundleEntryStats) as ChunkStats;
 
       // Skip chunk source if options source is false
       if (!source) {
@@ -74,7 +74,7 @@ export default function extractRollupStats(bundle: OutputBundle, options: StatsO
           return;
         }
 
-        let moduleStats = structuredClone(bundleModuleStats) as ModuleStats;
+        let moduleStats = cloneWithGettersUsingStructuredClone(bundleModuleStats) as ModuleStats;
 
         // Skip module source if options source is false
         if (!source) {
@@ -93,4 +93,24 @@ export default function extractRollupStats(bundle: OutputBundle, options: StatsO
   });
   
   return output;
+}
+
+/**
+ * Clone an object with getters using structuredClone
+ */
+function cloneWithGettersUsingStructuredClone<T extends Record<any, any>>(obj: T) {
+  const plainObject: any = {};
+
+  for (const key of Reflect.ownKeys(obj)) {
+    const descriptor = Object.getOwnPropertyDescriptor(obj, key);
+
+    if (descriptor?.get) {
+      plainObject[key] = obj[key as keyof typeof obj];
+    } else {
+      plainObject[key] = obj[key as keyof typeof obj];
+    }
+  }
+
+  // Use structuredClone to deeply clone the resulting plain object
+  return structuredClone(plainObject) as typeof obj;
 }

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -45,7 +45,7 @@ export default function extractRollupStats(bundle: OutputBundle, options: StatsO
     }
 
     if (bundleEntryStats.type === "asset") {
-      let assetStats = cloneWithGettersUsingStructuredClone(bundleEntryStats) as AssetStats;
+      let assetStats = structuredClone({ ...bundleEntryStats }) as AssetStats;
 
       // Skip asset source if options source is false
       if (!source) {
@@ -58,7 +58,7 @@ export default function extractRollupStats(bundle: OutputBundle, options: StatsO
     }
 
     if (bundleEntryStats.type === "chunk") {
-      let chunkStats = cloneWithGettersUsingStructuredClone(bundleEntryStats) as ChunkStats;
+      let chunkStats = structuredClone({ ...bundleEntryStats }) as ChunkStats;
 
       // Skip chunk source if options source is false
       if (!source) {
@@ -74,7 +74,7 @@ export default function extractRollupStats(bundle: OutputBundle, options: StatsO
           return;
         }
 
-        let moduleStats = cloneWithGettersUsingStructuredClone(bundleModuleStats) as ModuleStats;
+        let moduleStats = structuredClone({ ...bundleModuleStats }) as ModuleStats;
 
         // Skip module source if options source is false
         if (!source) {
@@ -93,18 +93,4 @@ export default function extractRollupStats(bundle: OutputBundle, options: StatsO
   });
   
   return output;
-}
-
-/**
- * Clone an object with getters using structuredClone
- */
-function cloneWithGettersUsingStructuredClone<T extends Record<any, any>>(obj: T) {
-  const plainObject: any = {};
-
-  for (const key of Reflect.ownKeys(obj)) {
-    plainObject[key] = obj[key as keyof typeof obj];
-  }
-
-  // Use structuredClone to deeply clone the resulting plain object
-  return structuredClone(plainObject) as typeof obj;
 }


### PR DESCRIPTION
Related: https://github.com/vitejs/rolldown-vite/issues/128

The new rust-based bundler, https://github.com/rolldown/rolldown/, has `getter`s as part of its output, which let `structuredClone` fail.

This PR adds a workaround which resolves getters first and then uses `structuredClone`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of data cloning to ensure all properties, including those accessed via getters, are correctly included in statistics displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->