### PR TITLE
feat: Extract - optionally extract the map property

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ export default defineConfig({
 - `write` - format and write the stats to disk(default: `fs.write(filename, JSON.stringify(stats, null, 2))`)
 - `stats` 
     - `source` - output asset/chunk/module source (default `false`)
+    - `map` - output chunk map property (default: `false`)
     - `excludeAssets` - exclude matching assets: `string | RegExp | ((filepath: string) => boolean) | Array<string | RegExp | ((filepath: string) => boolean)>`
     - `excludeModules` - exclude matching modules: `string | RegExp | ((filepath: string) => boolean) | Array<string | RegExp | ((filepath: string) => boolean)>`
 

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -16,6 +16,7 @@ export type ModuleStats = Omit<RenderedModule, keyof ModuleStatsOptionalProperti
 
 export type ChunkStatsOptionalProperties = {
   code?: OutputChunk['code'];
+  map?: OutputChunk['map']; 
 };
 
 export type ChunkStats = Omit<OutputChunk, keyof ChunkStatsOptionalProperties | 'modules'> & {
@@ -30,6 +31,11 @@ export type StatsOptions = {
    * @default false 
    */
   source?: boolean;
+  /**
+   * Output chunk map
+   * @default false 
+   */
+  map?: boolean;
   /**
    * Exclude matching assets
    */
@@ -50,7 +56,7 @@ export type StatsOptions = {
  * @NOTE structuredClone is not supported by rolldown-vite: https://github.com/vitejs/rolldown-vite/issues/128
  */
 export default function extractRollupStats(bundle: OutputBundle, options: StatsOptions = {}): Stats {
-  const { source = false, excludeAssets, excludeModules } = options;
+  const { source = false, map = false, excludeAssets, excludeModules } = options;
 
   const output: Stats = {};
 
@@ -82,6 +88,11 @@ export default function extractRollupStats(bundle: OutputBundle, options: StatsO
       // Skip chunk source if options.source is false
       if (!source) {
         chunkStatsOmitKeys.push('code');
+      }
+
+      // Skip chunk map if options.map is false
+      if (!map) {
+        chunkStatsOmitKeys.push('map');
       }
 
       const chunkStats = omit(bundleEntryStats, chunkStatsOmitKeys) as ChunkStats;

--- a/test/unit/__snapshots__/extract.test.ts.snap
+++ b/test/unit/__snapshots__/extract.test.ts.snap
@@ -66,6 +66,37 @@ exports[`extract > should extract rollup stats with excluded modules 1`] = `
 }
 `;
 
+exports[`extract > should extract rollup stats with maps 1`] = `
+{
+  "assets/logo.abcd1234.svg": {
+    "fileName": "assets/logo.abcd1234.svg",
+    "type": "asset",
+  },
+  "assets/main.abcd1234.js": {
+    "fileName": "assets/main.abcd1234.js",
+    "map": {
+      "version": "3",
+    },
+    "modules": {
+      "/home/user/project/src/main.js": {},
+      "/home/user/project/src/utils.js": {},
+    },
+    "type": "chunk",
+  },
+  "assets/vendors.abcd1234.js": {
+    "fileName": "assets/vendors.abcd1234.js",
+    "map": {
+      "version": "3",
+    },
+    "modules": {
+      "/home/user/project/node_modules/package-a/index.js": {},
+      "/home/user/project/node_modules/package-b/index.js": {},
+    },
+    "type": "chunk",
+  },
+}
+`;
+
 exports[`extract > should extract rollup stats with sources 1`] = `
 {
   "assets/logo.abcd1234.svg": {

--- a/test/unit/extract.test.ts
+++ b/test/unit/extract.test.ts
@@ -13,6 +13,10 @@ describe('extract', () => {
     expect(extract(deepFreeze(rollupStats.stats), { source: true })).toMatchSnapshot();
   });
 
+  test('should extract rollup stats with maps', () => {
+    expect(extract(deepFreeze(rollupStats.stats), { map: true })).toMatchSnapshot();
+  });
+
   test('should extract rollup stats with excluded assets', () => {
     expect(extract(deepFreeze(rollupStats.stats), { excludeAssets : /vendors/ })).toMatchSnapshot();
   });

--- a/test/unit/fixtures/rollup-stats.ts
+++ b/test/unit/fixtures/rollup-stats.ts
@@ -16,6 +16,7 @@ export const stats = {
         code: 'export default function () {}',
       },
     },
+    map: { version: "3" },
   },
   'assets/vendors.abcd1234.js': {
     fileName: 'assets/vendors.abcd1234.js',
@@ -29,5 +30,6 @@ export const stats = {
         code: 'export default function () {}',
       },
     },
+    map: { version: "3" },
   },
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optionally including chunk source maps in extracted stats via a new configuration option.
* **Documentation**
  * Updated documentation to describe the new option for including source maps in stats output.
* **Tests**
  * Added tests to verify correct handling of the new source map option in stats extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->