### PR TITLE
Support Vite v8 peerDependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       matrix:
         node: ["24", "22", "20", "18"]
         os: [ubuntu-latest, windows-latest]
-        vite: ["5", "6", "7"]
+        vite: ["5", "6", "7", "8"]
         exclude:
           - os: windows-latest
             node: 22
@@ -173,6 +173,8 @@ jobs:
           - os: windows-latest
             node: 18
           - vite: 7
+            node: 18
+          - vite: 8
             node: 18
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rollup-plugin-stats",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rollup-plugin-stats",
-      "version": "2.0.0",
+      "version": "2.1.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "peerDependencies": {
     "rolldown": "^1.0.0-beta.0",
     "rollup": "^3.0.0 || ^4.0.0",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "vite": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rollup-plugin-stats",
   "description": "Vite/Rolldown/Rollup plugin to generate bundle stats JSON file",
-  "version": "2.0.0",
+  "version": "2.1.0-beta.0",
   "license": "MIT",
   "private": false,
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     /* target config for node 18 */
     "target": "es2022",
     "lib": ["es2022", "es2022.error"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     /* behaviour options */


### PR DESCRIPTION
- **build: tsconfig - use moduleResolution=bundler**
- **build: Add vite v8 peer dependency**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended CI testing matrix to include Vite 8 and added an exclusion for the Vite 8 + Node 18 combination.
  * Updated peer dependency to support Vite 8.
  * Bumped package version to 2.1.0-beta.0.
  * Adjusted TypeScript configuration to use a different module resolution strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->