### PR TITLE
type: Export inline types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,9 @@
         "prettier": "3.8.1",
         "release-it": "19.2.4",
         "rimraf": "6.1.3",
-        "rollup": "4.59.0",
         "tsdown": "0.21.2",
         "typescript": "5.9.3",
         "typescript-eslint": "8.57.0",
-        "vite": "7.3.1",
         "vitest": "4.1.0"
       },
       "engines": {
@@ -36,7 +34,7 @@
       "peerDependencies": {
         "rolldown": "^1.0.0-beta.0",
         "rollup": "^3.0.0 || ^4.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "rolldown": {
@@ -183,7 +181,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -200,7 +197,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -217,7 +213,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -234,7 +229,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -251,7 +245,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -268,7 +261,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -285,7 +277,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -302,7 +293,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -319,7 +309,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -336,7 +325,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -353,7 +341,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -370,7 +357,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -387,7 +373,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -404,7 +389,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -421,7 +405,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -438,7 +421,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -455,7 +437,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -472,7 +453,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -489,7 +469,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -506,7 +485,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -523,7 +501,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -540,7 +517,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -557,7 +533,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -574,7 +549,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -591,7 +565,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -608,7 +581,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2117,7 +2089,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2131,7 +2102,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2145,7 +2115,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2159,7 +2128,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2173,7 +2141,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2187,7 +2154,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2201,7 +2167,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2215,7 +2180,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2229,7 +2193,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2243,7 +2206,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2257,7 +2219,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2271,7 +2232,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2285,7 +2245,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2299,7 +2258,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2313,7 +2271,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2327,7 +2284,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2341,7 +2297,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2355,7 +2310,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2369,7 +2323,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2383,7 +2336,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2397,7 +2349,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2411,7 +2362,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2425,7 +2375,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2439,7 +2388,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2453,7 +2401,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2580,7 +2527,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/jsesc": {
@@ -2601,7 +2548,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -3813,7 +3760,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -4207,7 +4154,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -4289,7 +4236,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4835,7 +4781,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5372,7 +5318,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5798,14 +5744,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5830,7 +5776,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6173,7 +6119,7 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -6432,7 +6378,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6605,7 +6551,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -6867,7 +6813,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -6946,7 +6892,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -7255,7 +7201,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -86,11 +86,9 @@
     "prettier": "3.8.1",
     "release-it": "19.2.4",
     "rimraf": "6.1.3",
-    "rollup": "4.59.0",
     "tsdown": "0.21.2",
     "typescript": "5.9.3",
     "typescript-eslint": "8.57.0",
-    "vite": "7.3.1",
     "vitest": "4.1.0"
   },
   "peerDependencies": {

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,14 +1,15 @@
+import { omit } from './utils/omit';
+
+import {
+  type ExcludeFilepathPatterns,
+  checkExcludeFilepath,
+} from './utils/check-exclude-filepath';
 import type {
   OutputAsset,
   OutputBundle,
   OutputChunk,
   RenderedModule,
-} from 'rollup';
-import { omit } from './utils/omit';
-import {
-  type ExcludeFilepathPatterns,
-  checkExcludeFilepath,
-} from './utils/check-exclude-filepath';
+} from './types';
 
 export type AssetStatsOptionalProperties = {
   source?: OutputAsset['source'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,70 +1,16 @@
-import path from 'node:path';
-import process from 'node:process';
+import { rollupStats } from './plugin';
 
-import extractRollupStats, { type StatsOptions } from './extract';
-import { type RollupStatsWrite, rollupStatsWrite } from './write';
-import { formatFileSize } from './utils/format-file-size';
-import type { Plugin, OutputOptions } from './types';
+export type {
+  RollupStatsOptions,
+  RollupStatsOptionsOrOutputOptions,
+} from './plugin';
 
-const PLUGIN_NAME = 'rollupStats';
-const DEFAULT_FILE_NAME = 'stats.json';
-
-export type RollupStatsOptions = {
-  /**
-   * Output filename relative to Rollup output directory or absolute
-   * @default: stats.json
-   */
-  fileName?: string;
-  /**
-   * Rollup stats options
-   */
-  stats?: StatsOptions;
-  /**
-   * Custom file writer
-   * @default - fs.write(FILENAME, JSON.stringify(STATS, null, 2));
-   */
-  write?: RollupStatsWrite;
-};
-
-type RollupStatsOptionsOrOutputOptions =
-  | RollupStatsOptions
-  | ((outputOptions: OutputOptions) => RollupStatsOptions);
-
-function rollupStats(options: RollupStatsOptionsOrOutputOptions = {}): Plugin {
-  return {
-    name: PLUGIN_NAME,
-    async generateBundle(context, bundle) {
-      const resolvedOptions =
-        typeof options === 'function' ? options(context) : options;
-      const {
-        fileName,
-        stats: statsOptions,
-        write = rollupStatsWrite,
-      } = resolvedOptions || {};
-
-      const resolvedFileName = fileName || DEFAULT_FILE_NAME;
-      const filepath = path.isAbsolute(resolvedFileName)
-        ? resolvedFileName
-        : path.join(context.dir || process.cwd(), resolvedFileName);
-
-      const stats = extractRollupStats(bundle, statsOptions);
-
-      try {
-        const res = await write(filepath, stats);
-        const outputSize = Buffer.byteLength(res.content, 'utf-8');
-
-        this.info(
-          `Stats saved to ${res.filepath} (${formatFileSize(outputSize)})`
-        );
-      } catch (error: unknown) {
-        const message =
-          error instanceof Error ? error.message : JSON.stringify(error);
-
-        // Log error, but do not throw to allow the compilation to continue
-        this.warn(message);
-      }
-    },
-  } satisfies Plugin;
-}
+export type {
+  OutputAsset,
+  OutputBundle,
+  OutputChunk,
+  RenderedModule,
+  SourceMap,
+} from './types';
 
 export default rollupStats;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,130 @@
+import path from 'node:path';
+import process from 'node:process';
+
+import extractRollupStats, { type StatsOptions } from './extract';
+import { type RollupStatsWrite, rollupStatsWrite } from './write';
+import { formatFileSize } from './utils/format-file-size';
+import type { OutputBundle } from './types';
+
+const PLUGIN_NAME = 'rollupStats';
+const DEFAULT_FILE_NAME = 'stats.json';
+
+/**
+ * A subset of resolved output options provided to the `generateBundle` hook by Vite/Rolldown/Rollup,
+ * containing only the fields this plugin uses to generate a stats file for a specific output.
+ */
+export type OutputOptions = {
+  /** Output directory for the generated files. */
+  dir?: string | undefined;
+
+  /** Output format */
+  format?:
+    | 'es'
+    | 'esm'
+    | 'module'
+    | 'cjs'
+    | 'commonjs'
+    | 'iife'
+    | 'umd'
+    | 'amd'
+    | 'system'
+    | 'systemjs'
+    | undefined;
+};
+
+/**
+ * Subset of the Vite/Rolldown/Rollup plugin hook context (`this`) used by this plugin.
+ */
+type PluginContext = {
+  /** Log an informational message through Vite/Rolldown/Rollup's logging pipeline. */
+  info: (message: string) => void;
+
+  /** Log a warning through Vite/Rolldown/Rollup's logging pipeline without stopping the build. */
+  warn: (message: string) => void;
+};
+
+/**
+ * Minimum plugin interface compatible with Vite/Rolldown/Rollup.
+ *
+ * @example
+ * {
+ *   name: 'rollupStats',
+ *   async generateBundle(outputOptions, bundle) { ... },
+ * }
+ */
+export type Plugin = {
+  /** Unique identifier for the plugin, used in error messages and logs. */
+  name: string;
+
+  /**
+   * Hook called after the bundle has been fully generated but before it is
+   * written to disk. Receives the resolved output options and the complete
+   * output bundle map.
+   */
+  generateBundle?: (
+    this: PluginContext,
+    outputOptions: OutputOptions,
+    bundle: OutputBundle,
+    isWrite: boolean
+  ) => void | Promise<void>;
+};
+
+export type RollupStatsOptions = {
+  /**
+   * Output filename relative to Rollup output directory or absolute
+   * @default: stats.json
+   */
+  fileName?: string;
+  /**
+   * Rollup stats options
+   */
+  stats?: StatsOptions;
+  /**
+   * Custom file writer
+   * @default - fs.write(FILENAME, JSON.stringify(STATS, null, 2));
+   */
+  write?: RollupStatsWrite;
+};
+
+export type RollupStatsOptionsOrOutputOptions =
+  | RollupStatsOptions
+  | ((outputOptions: OutputOptions) => RollupStatsOptions);
+
+export function rollupStats(
+  options: RollupStatsOptionsOrOutputOptions = {}
+): Plugin {
+  return {
+    name: PLUGIN_NAME,
+    async generateBundle(context, bundle) {
+      const resolvedOptions =
+        typeof options === 'function' ? options(context) : options;
+      const {
+        fileName,
+        stats: statsOptions,
+        write = rollupStatsWrite,
+      } = resolvedOptions || {};
+
+      const resolvedFileName = fileName || DEFAULT_FILE_NAME;
+      const filepath = path.isAbsolute(resolvedFileName)
+        ? resolvedFileName
+        : path.join(context.dir || process.cwd(), resolvedFileName);
+
+      const stats = extractRollupStats(bundle, statsOptions);
+
+      try {
+        const res = await write(filepath, stats);
+        const outputSize = Buffer.byteLength(res.content, 'utf-8');
+
+        this.info(
+          `Stats saved to ${res.filepath} (${formatFileSize(outputSize)})`
+        );
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error ? error.message : JSON.stringify(error);
+
+        // Log error, but do not throw to allow the compilation to continue
+        this.warn(message);
+      }
+    },
+  } satisfies Plugin;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,190 @@
-import type {
-  Plugin as RollupPlugin,
-  OutputOptions as RollupOutputOptions,
-  OutputBundle as RollupOutputBundle,
-} from 'rollup';
-import type { Plugin as VitePlugin } from 'vite';
+/**
+ * Standard source map v3 object mapping generated code back to original sources.
+ *
+ * @see https://sourcemaps.info/spec.html
+ * @see https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts#L98
+ * @see https://github.com/rolldown/rolldown/blob/main/packages/rolldown/src/types/rolldown-output.ts#L26
+ */
+export type SourceMap = {
+  /** Name of the generated file this source map corresponds to. */
+  file: string;
+  /** Base64 VLQ-encoded string describing the source mappings. */
+  mappings: string;
+  /** Original symbol names referenced by the mappings. */
+  names: string[];
+  /** Paths to the original source files. */
+  sources: string[];
+  /** Optional inline content of each original source file, parallel to `sources`. */
+  sourcesContent?: string[] | undefined;
+  /** Source map specification version — always `3`. */
+  version: number;
+};
 
-export type Plugin = VitePlugin & RollupPlugin;
-export type OutputOptions = RollupOutputOptions;
-export type OutputBundle = RollupOutputBundle;
+/**
+ * A generated asset entry in the output bundle (e.g. CSS, images, JSON).
+ *
+ * @see https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts#L958
+ * @see https://github.com/rolldown/rolldown/blob/main/packages/rolldown/src/types/rolldown-output.ts#L85
+ */
+export type OutputAsset = {
+  type: 'asset';
+
+  /** The emitted file name of the asset relative to the output directory. */
+  fileName: string;
+
+  /**
+   * The asset name, or `undefined` when not available.
+   * @deprecated Use `names` instead.
+   */
+  name: string | undefined;
+
+  /** All entry names that reference this asset. */
+  names: string[];
+
+  /**
+   * The original file name of the source asset before any transformations, or `null` when not applicable.
+   * @deprecated Use `originalFileNames` instead.
+   */
+  originalFileName: string | null;
+
+  /** The original file names of the source assets before any transformations. */
+  originalFileNames: string[];
+
+  /**
+   * The asset content as a string (text assets) or a `Uint8Array` (binary assets).
+   * Available when options.stats.source = true (default false)
+   */
+  source?: string | Uint8Array;
+
+  /**
+   * Rollup - Whether this asset requires a code reference (`import.meta.ROLLUP_FILE_URL_<id>`)
+   * to be included in the bundle.
+   *
+   * @see https://github.com/rollup/rollup/issues/4774
+   */
+  needsCodeReference?: boolean;
+
+  /** Vite - specific metadata */
+  viteMetadata?: {
+    /** Set of asset file names imported by this asset (e.g. images referenced in CSS). */
+    importedAssets: Set<string>;
+    /** Set of CSS file names imported by this asset. */
+    importedCss: Set<string>;
+  };
+};
+
+/**
+ * Stats for an individual module included in an output chunk.
+ * @see https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts#L963
+ * @see https://github.com/rolldown/rolldown/blob/main/packages/rolldown/src/types/rolldown-output.ts#L40
+ */
+export type RenderedModule = {
+  /**
+   * The module code that Vite/Rolldown/Rollup included in the bundle, or `null` when the
+   * module was fully tree-shaken.
+   * Available only when options.stats.source = true (default false)
+   */
+  readonly code?: string | null;
+
+  /** Size of the original module source in bytes, before any transformations. */
+  originalLength: number;
+
+  /** Rollup - exports removed from this module by tree-shaking. */
+  removedExports?: string[];
+
+  /** Exports from this module that are retained in the final bundle. */
+  renderedExports: string[];
+
+  /** Rollup - size of the rendered module code in bytes. */
+  renderedLength?: number;
+};
+
+/**
+ * A generated JavaScript chunk entry in the output bundle.
+ *
+ * @see https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts#L992
+ * @see https://github.com/rolldown/rolldown/blob/main/packages/rolldown/src/types/rolldown-output.ts#L85
+ */
+export type OutputChunk = {
+  type: 'chunk';
+
+  /** The chunk name as used in `chunkFileNames` and `entryFileNames` patterns */
+  name: string;
+
+  /** The emitted file name of the chunk relative to the output directory. */
+  fileName: string;
+
+  /** The file name of this chunk before content hashes are applied. */
+  preliminaryFileName: string;
+
+  /** Rollup - file names of assets referenced via `import.meta.ROLLUP_FILE_URL_<id>` in this chunk. */
+  referencedFiles?: string[];
+
+  /** The file name of the source map for this chunk, or `null` when source maps are not generated. */
+  sourcemapFileName: string | null;
+
+  /** Names exported by this chunk. */
+  exports: string[];
+
+  /**
+   * The module ID of the entry point that this chunk acts as a facade for,
+   * or `null` when this chunk is not an entry facade.
+   */
+  facadeModuleId: string | null;
+
+  /** Rollup - file names of chunks that should be loaded before this implicit entry point. */
+  implicitlyLoadedBefore?: string[];
+
+  /** Rollup - per-import binding names imported from each dependency chunk, keyed by the imported chunk's file name. */
+  importedBindings?: Record<string, string[]>;
+
+  /** Whether this chunk is a dynamic entry point (i.e. produced by a dynamic `import()`). */
+  isDynamicEntry: boolean;
+
+  /** Whether this chunk is a static entry point declared in the Vite/Rolldown/Rollup input options. */
+  isEntry: boolean;
+
+  /** Rollup - whether this chunk is an implicit entry point, loaded after another entry via `implicitlyLoadedAfterOneOf`. */
+  isImplicitEntry?: boolean;
+
+  /** File names of chunks that are dynamically imported by this chunk. */
+  dynamicImports: string[];
+
+  /** File names of chunks that are statically imported by this chunk. */
+  imports: string[];
+
+  /**
+   * Per-module render stats for every module included in this chunk,
+   * keyed by the module's original file path.
+   */
+  modules: Record<string, RenderedModule>;
+
+  /** IDs of all modules included in this chunk, in the order they appear in the bundle. */
+  moduleIds: string[];
+
+  /**
+   * The rendered JavaScript source code of this chunk.
+   * Available when options.stats.source = true (default false)
+   */
+  code?: string;
+
+  /**
+   * Source map for this chunk, or `null` when source maps are not enabled.
+   * Available when options.stats.source = true (default: false)
+   */
+  map?: SourceMap | null;
+
+  /** Vite - Optional specific metadata */
+  viteMetadata?: {
+    /** Set of asset file names imported by this chunk (e.g. images, fonts). */
+    importedAssets: Set<string>;
+    /** Set of CSS file names imported by this chunk. */
+    importedCss: Set<string>;
+  };
+};
+
+/**
+ * The complete output bundle produced by Vite/Rolldown/Rollup — a map from emitted file name
+ * to its corresponding asset or chunk descriptor.
+ */
+export type OutputBundle = Record<string, OutputAsset | OutputChunk>;


### PR DESCRIPTION
avoid re-exporting vite/rollup unions, they can fail in vite 8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released v2.1.1-beta.3.
  * Removed rollup and vite from devDependencies in package metadata.

* **New Features**
  * Plugin implementation now exported from a dedicated module and published as the package default export.
  * Additional public typings for bundle assets, chunks, and modules are now exported.

* **Refactor**
  * Replaced external tooling type passthroughs with explicit internal type definitions; runtime behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->