### PR TITLE
test: Remove bundler dependency from package.json to avoid npm errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
       - name: "Install test package dependencies"
         run: |
           npm install
+          npm install rolldown
           npx rolldown -v
         working-directory: test/package/rolldown
 

--- a/test/package/rolldown/package.json
+++ b/test/package/rolldown/package.json
@@ -9,7 +9,7 @@
   "keywords": [],
   "license": "ISC",
   "devDependencies": {
-    "rolldown": "^1.0.0-beta.21",
+    "rolldown": "^1.0.0-rc.15",
     "rollup-plugin-stats": "*"
   }
 }

--- a/test/package/rollup/package.json
+++ b/test/package/rollup/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.0.0",
     "cross-env": "^7.0.0",
-    "rollup": "^4.0.0",
     "rollup-plugin-stats": "*",
     "typescript": "^5.0.0"
   }

--- a/test/package/vite/package.json
+++ b/test/package/vite/package.json
@@ -13,7 +13,6 @@
   "license": "ISC",
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "rollup-plugin-stats": "*",
-    "vite": "^7.0.0"
+    "rollup-plugin-stats": "*"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated rolldown test dependency to a newer release candidate version.
  * Removed rollup and vite from test package dependencies.
  * Updated CI workflow to explicitly install rolldown during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->